### PR TITLE
User NSData *xml instead of NSString in calculation to deal with large file

### DIFF
--- a/xmlwriter/XMLWriter.h
+++ b/xmlwriter/XMLWriter.h
@@ -1,20 +1,24 @@
 //
 // XMLWriter.h
 //
+//  Changed by RealZYC on 10/31/2016
+//
 
 #import <Foundation/Foundation.h>
 
 @interface XMLWriter : NSObject{
 @private
     NSMutableArray* nodes;
-    NSString* xml;
+    NSMutableData* xml;
     NSMutableArray* treeNodes;
     BOOL isRoot;
     NSString* passDict;
     BOOL withHeader;
 }
++(NSData *)XMLDataFromDictionary:(NSDictionary *)dictionary; //New
++(NSData *)XMLDataFromDictionary:(NSDictionary *)dictionary withHeader:(BOOL)header; //New
 +(NSString *)XMLStringFromDictionary:(NSDictionary *)dictionary;
 +(NSString *)XMLStringFromDictionary:(NSDictionary *)dictionary withHeader:(BOOL)header;
-+(BOOL)XMLDataFromDictionary:(NSDictionary *)dictionary toStringPath:(NSString *) path  Error:(NSError **)error;
++(BOOL)XMLDataFromDictionary:(NSDictionary *)dictionary toStringPath:(NSString *)path  Error:(NSError **)error;
 
 @end


### PR DESCRIPTION
Currently `NSString *xml` is used in calculation. But when the xml file is big, say 10000 items in NSDictionary, the `[NSString stringByAppendingFormat:]` will crush with error message "Message from debugger: Terminated due to memory issue".

So it's better to change NSString to NSData in calculation, and that's what I changed.

By the way, two new functions are provided.

```
+(NSData *)XMLDataFromDictionary:(NSDictionary *)dictionary; //New
+(NSData *)XMLDataFromDictionary:(NSDictionary *)dictionary withHeader:(BOOL)header; //
```

